### PR TITLE
PR 3: auth module

### DIFF
--- a/corphish/auth.py
+++ b/corphish/auth.py
@@ -75,7 +75,10 @@ def _load_token(token_path: Path) -> Optional[Credentials]:
     """
     if not token_path.exists():
         return None
-    return Credentials.from_authorized_user_file(str(token_path), SCOPES)
+    try:
+        return Credentials.from_authorized_user_file(str(token_path), SCOPES)
+    except Exception:
+        return None
 
 
 def _save_token(creds: Credentials, token_path: Path) -> None:
@@ -86,4 +89,6 @@ def _save_token(creds: Credentials, token_path: Path) -> None:
         token_path: Destination path for the token file.
     """
     token_path.parent.mkdir(parents=True, exist_ok=True)
-    token_path.write_text(creds.to_json())
+    tmp = token_path.with_suffix(".tmp")
+    tmp.write_text(creds.to_json())
+    tmp.replace(token_path)


### PR DESCRIPTION
## Summary
- Adds `corphish/auth.py` with the full OAuth2 credential lifecycle
- Loads cached token, refreshes silently if expired, runs browser flow if absent
- Raises `FileNotFoundError` with human-readable setup instructions if `client_secret.json` is missing
- `flow_factory` parameter makes the browser flow injectable for tests — no real network calls

## Test plan
- [x] Missing `client_secret.json` raises `FileNotFoundError` with path in message
- [x] Valid cached token returned directly without hitting the flow
- [x] Expired token refreshed silently and saved back to disk
- [x] No token triggers browser flow via `run_local_server(port=0)`
- [x] New token from flow saved to disk
- [x] `flow_factory` receives correct path and scopes
- [x] 9 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)