### PR TITLE
PR 4: chat module

### DIFF
--- a/corphish/chat.py
+++ b/corphish/chat.py
@@ -1,0 +1,60 @@
+"""Google Chat API operations."""
+
+from typing import Any
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+
+def build_service(creds: Credentials) -> Any:
+    """Builds a Google Chat API service resource.
+
+    Args:
+        creds: Valid OAuth2 credentials authorised for Chat API scopes.
+
+    Returns:
+        A googleapiclient Resource for the Chat v1 API.
+    """
+    return build("chat", "v1", credentials=creds)
+
+
+def create_space(service: Any, display_name: str = "Corphish") -> dict:
+    """Creates a new Google Chat space.
+
+    Args:
+        service: A Chat API service resource from build_service().
+        display_name: Human-readable name for the space.
+
+    Returns:
+        The API response dict, including the space's resource name under
+        the key "name" (e.g. "spaces/abc123").
+    """
+    return (
+        service.spaces()
+        .create(body={"displayName": display_name, "spaceType": "SPACE"})
+        .execute()
+    )
+
+
+def send_message(service: Any, space_name: str, text: str) -> dict:
+    """Sends a text message to a Google Chat space.
+
+    Args:
+        service: A Chat API service resource from build_service().
+        space_name: The resource name of the space (e.g. "spaces/abc123").
+        text: The message text to send.
+
+    Returns:
+        The API response dict for the created message.
+
+    Raises:
+        ValueError: If space_name is empty.
+    """
+    if not space_name:
+        raise ValueError("space_name must not be empty")
+    return (
+        service.spaces()
+        .messages()
+        .create(parent=space_name, body={"text": text})
+        .execute()
+    )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,82 @@
+"""Tests for corphish.chat."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from corphish.chat import build_service, create_space, send_message
+
+
+def test_build_service_calls_discovery():
+    mock_creds = MagicMock()
+    with patch("corphish.chat.build") as mock_build:
+        mock_build.return_value = MagicMock()
+        build_service(mock_creds)
+    mock_build.assert_called_once_with("chat", "v1", credentials=mock_creds)
+
+
+def test_build_service_returns_resource():
+    mock_creds = MagicMock()
+    mock_resource = MagicMock()
+    with patch("corphish.chat.build", return_value=mock_resource):
+        result = build_service(mock_creds)
+    assert result is mock_resource
+
+
+def test_create_space_default_display_name():
+    mock_service = MagicMock()
+    mock_service.spaces().create().execute.return_value = {
+        "name": "spaces/abc123",
+        "displayName": "Corphish",
+    }
+    create_space(mock_service)
+    mock_service.spaces().create.assert_called_with(
+        body={"displayName": "Corphish", "spaceType": "SPACE"}
+    )
+
+
+def test_create_space_custom_display_name():
+    mock_service = MagicMock()
+    mock_service.spaces().create().execute.return_value = {
+        "name": "spaces/abc123",
+        "displayName": "My Space",
+    }
+    create_space(mock_service, display_name="My Space")
+    mock_service.spaces().create.assert_called_with(
+        body={"displayName": "My Space", "spaceType": "SPACE"}
+    )
+
+
+def test_create_space_returns_response():
+    mock_service = MagicMock()
+    expected = {"name": "spaces/abc123", "displayName": "Corphish"}
+    mock_service.spaces().create().execute.return_value = expected
+    result = create_space(mock_service)
+    assert result == expected
+
+
+def test_send_message_calls_api():
+    mock_service = MagicMock()
+    mock_service.spaces().messages().create().execute.return_value = {
+        "name": "spaces/abc123/messages/1"
+    }
+    send_message(mock_service, "spaces/abc123", "Hello!")
+    mock_service.spaces().messages().create.assert_called_with(
+        parent="spaces/abc123", body={"text": "Hello!"}
+    )
+
+
+def test_send_message_returns_response():
+    mock_service = MagicMock()
+    expected = {"name": "spaces/abc123/messages/1"}
+    mock_service.spaces().messages().create().execute.return_value = expected
+    result = send_message(mock_service, "spaces/abc123", "Hello!")
+    assert result == expected
+
+
+def test_send_message_empty_space_name_raises():
+    mock_service = MagicMock()
+    with pytest.raises(ValueError, match="space_name must not be empty"):
+        send_message(mock_service, "", "Hello!")
+
+


### PR DESCRIPTION
## Summary
- Adds `corphish/chat.py` with Google Chat API operations
- `build_service()` — constructs a Chat v1 API resource from credentials
- `create_space()` — creates a new space, accepts optional display name
- `send_message()` — sends a text message; raises `ValueError` on empty space name

## Test plan
- [x] `build_service` calls `googleapiclient.discovery.build` with correct args
- [x] `create_space` sends correct request body with default and custom display names
- [x] `create_space` returns the API response dict
- [x] `send_message` sends correct parent and body
- [x] `send_message` returns the API response dict
- [x] `send_message` raises `ValueError` on empty space name
- [x] 8 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)