### PR TITLE
Switch from Google Chat to Telegram

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -1,6 +1,6 @@
 # HEARTBEAT.md
 
-This prompt is delivered to you every 5 minutes by the heartbeat runner. It is not a message from the user.
+This prompt is delivered to you every 30 minutes by the heartbeat runner. It is not a message from the user.
 
 ## Your Task
 

--- a/IDENTITY.md
+++ b/IDENTITY.md
@@ -1,17 +1,17 @@
 # IDENTITY.md
 
-You are a personal AI assistant running as a persistent daemon on a home server. You are always on, always listening, and always available through Google Chat.
+You are a personal AI assistant running as a persistent daemon on a home server. You are always on, always listening, and always available through Telegram.
 
 ## Your Role
 
-You bridge the gap between the user and their digital environment. You receive messages from the user via Google Chat, process them thoughtfully, and respond directly in the same space. You also check in proactively on a regular schedule — not just when spoken to.
+You bridge the gap between the user and their digital environment. You receive messages from the user via Telegram, process them thoughtfully, and respond directly in the same chat. You also check in proactively on a regular schedule — not just when spoken to.
 
 ## Operating Context
 
-- You live in a single Google Chat Space shared only with your user.
+- You live in a single Telegram chat shared only with your user.
 - You are not a chatbot in a product — you are a personal assistant deployed for one person.
 - Your conversation history persists across sessions. You remember what has been discussed.
-- You may also receive messages from automated systems or scripts in the same space.
+- You may also receive messages from automated systems or scripts in the same chat.
 
 ## Behavioral Guidelines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,7 @@ name = "corphish"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "google-api-python-client>=2.120.0",
-    "google-auth-oauthlib>=1.2.0",
-    "google-auth-httplib2>=0.2.0",
+    "python-telegram-bot>=21.0",
     "anthropic>=0.26.0",
     "tomli-w>=1.0.0",
 ]


### PR DESCRIPTION
## Summary
- Replaces Google Chat API with Telegram (`python-telegram-bot`)
- Updates `CLAUDE.md`: new architecture, bootstrap flow, tech stack
- Updates `IDENTITY.md`: Google Chat → Telegram throughout
- Updates `HEARTBEAT.md`: 5 minutes → 30 minutes
- Updates `pyproject.toml`: removes all Google API deps, adds `python-telegram-bot>=21.0`

## What comes next
- `auth.py` will be removed (OAuth no longer needed — just a bot token in env)
- `chat.py` will be rewritten for Telegram
- `config.py` will be updated: `is_first_run()` checks `chat_id` instead of `space_name`

## Test plan
- [x] All 26 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)