### PR TITLE
Fix daemon crash from unclosed async generator

### DIFF
--- a/corphish/claude_client.py
+++ b/corphish/claude_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from contextlib import aclosing
 from pathlib import Path
 from typing import Optional
 
@@ -123,19 +124,20 @@ class ClaudeClient:
         """
         last_text = ""
 
-        async for message in self._query(
-            prompt=user_text, options=self._options
-        ):
-            if isinstance(message, AssistantMessage):
-                parts = [
-                    block.text
-                    for block in message.content
-                    if isinstance(block, TextBlock)
-                ]
-                if parts:
-                    last_text = "\n".join(parts)
-            elif isinstance(message, ResultMessage):
-                if message.result:
-                    return message.result
+        async with aclosing(
+            self._query(prompt=user_text, options=self._options)
+        ) as stream:
+            async for message in stream:
+                if isinstance(message, AssistantMessage):
+                    parts = [
+                        block.text
+                        for block in message.content
+                        if isinstance(block, TextBlock)
+                    ]
+                    if parts:
+                        last_text = "\n".join(parts)
+                elif isinstance(message, ResultMessage):
+                    if message.result:
+                        return message.result
 
         return last_text

--- a/corphish/daemon.py
+++ b/corphish/daemon.py
@@ -61,7 +61,11 @@ async def run_daemon(
     logger.info("Daemon started, listening on chat %s", chat_id)
 
     while True:
-        updates = await poll(bot, offset)
+        try:
+            updates = await poll(bot, offset)
+        except Exception:
+            logger.exception("Failed to poll updates")
+            updates = []
 
         for update in updates:
             offset = update.update_id + 1

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -380,3 +380,78 @@ async def test_lock_serialises_calls():
         "start-a",
         "end-a",
     ]
+
+
+# ---------------------------------------------------------------------------
+# send() — async generator cleanup (issue #27)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_closes_generator_on_early_return():
+    """Generator must be closed when send() returns via ResultMessage.result.
+
+    Regression test for issue #27: leaving the async generator open caused
+    RuntimeError (anyio cancel scope) when GC ran aclose() in a different task.
+    """
+    from claude_agent_sdk import AssistantMessage, TextBlock, ResultMessage
+
+    closed = False
+
+    async def gen_query(*, prompt, options):
+        nonlocal closed
+        try:
+            yield AssistantMessage(
+                content=[TextBlock(text="intermediate")], model="test"
+            )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=100,
+                duration_api_ms=80,
+                is_error=False,
+                num_turns=1,
+                session_id="s1",
+                result="final",
+            )
+            # This code would run if generator were not closed after early return
+            yield AssistantMessage(
+                content=[TextBlock(text="should not reach")], model="test"
+            )
+        except GeneratorExit:
+            closed = True
+            raise
+        finally:
+            closed = True
+
+    client = _make_client(query_fn=gen_query)
+    result = await client.send("test")
+    assert result == "final"
+    assert closed, "async generator was not properly closed"
+
+
+async def test_send_closes_generator_on_normal_exhaustion():
+    """Generator cleanup works on the normal (no early return) path too."""
+    from claude_agent_sdk import AssistantMessage, TextBlock, ResultMessage
+
+    closed = False
+
+    async def gen_query(*, prompt, options):
+        nonlocal closed
+        try:
+            yield AssistantMessage(
+                content=[TextBlock(text="hello")], model="test"
+            )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=100,
+                duration_api_ms=80,
+                is_error=False,
+                num_turns=1,
+                session_id="s1",
+            )
+        finally:
+            closed = True
+
+    client = _make_client(query_fn=gen_query)
+    result = await client.send("test")
+    assert result == "hello"
+    assert closed, "async generator was not properly closed"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -169,3 +169,15 @@ async def test_daemon_continues_after_telegram_send_failure():
 
     assert deps["claude"].send.await_count == 2
     assert deps["send_message_fn"].await_count == 2
+
+
+async def test_daemon_continues_after_poll_failure():
+    """If polling Telegram raises, the daemon should log and continue."""
+    deps = _make_deps(chat_id=42)
+    deps["poll_fn"] = AsyncMock(side_effect=RuntimeError("network error"))
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    # Should not crash — Claude and Telegram send should not be called
+    deps["claude"].send.assert_not_awaited()
+    deps["send_message_fn"].assert_not_awaited()


### PR DESCRIPTION
## Summary

Closes #27.

- **Root cause**: `claude_client.send()` iterates an async generator from the Agent SDK's `query()`. When it returned early on `ResultMessage.result`, the generator was left open. Python's GC later called `aclose()` in a different task context, triggering anyio's `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in`.
- **Fix**: Wrap the async generator with `contextlib.aclosing()` so it is always closed in the same task, regardless of early return.
- **Bonus**: Wrap `poll()` in try/except in the daemon loop so network errors during Telegram polling don't crash the process.

## Test plan

- [x] `test_send_closes_generator_on_early_return` — verifies generator is closed when `send()` returns early via `ResultMessage.result`
- [x] `test_send_closes_generator_on_normal_exhaustion` — verifies cleanup on normal path
- [x] `test_daemon_continues_after_poll_failure` — verifies daemon survives poll errors
- [x] All 88 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)