### PR TITLE
Persist Telegram update offset to prevent replay loop

### DIFF
--- a/corphish/cli.py
+++ b/corphish/cli.py
@@ -42,6 +42,10 @@ def build_parser() -> argparse.ArgumentParser:
     run_once_parser.add_argument("text", nargs="+", help="Message text to send")
 
     sub.add_parser("status", help="Show current configuration status")
+    sub.add_parser(
+        "skip-updates",
+        help="Advance offset past all pending Telegram updates",
+    )
     return parser
 
 
@@ -144,6 +148,39 @@ def cmd_status(
         out("Status: not bootstrapped")
 
 
+async def cmd_skip_updates(
+    *,
+    get_bot_token_fn: Callable = get_bot_token,
+    build_bot_fn: Callable = build_bot,
+    save_offset_fn: Callable = config.save_update_offset,
+) -> None:
+    """Advances the update offset past all pending Telegram updates.
+
+    Calls getUpdates with offset=-1 to fetch only the latest update,
+    then persists max(update_id) + 1 so the daemon will skip everything
+    currently queued.
+
+    Args:
+        get_bot_token_fn: Returns the Telegram bot token.
+        build_bot_fn: Creates a Bot from a token.
+        save_offset_fn: Persists the update offset.
+    """
+    try:
+        token = get_bot_token_fn()
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
+
+    bot = build_bot_fn(token)
+    updates = await bot.get_updates(offset=-1, timeout=0)
+    if updates:
+        new_offset = updates[-1].update_id + 1
+        save_offset_fn(new_offset)
+        logger.info("Skipped updates. Offset set to %d.", new_offset)
+    else:
+        logger.info("No pending updates to skip.")
+
+
 async def dispatch(args: argparse.Namespace) -> None:
     """Dispatches to the appropriate command handler.
 
@@ -163,6 +200,8 @@ async def dispatch(args: argparse.Namespace) -> None:
         await run_bootstrap()
     elif command == "status":
         cmd_status()
+    elif command == "skip-updates":
+        await cmd_skip_updates()
     else:
         # Default: run daemon (auto-bootstrap on first run)
         if config.is_first_run():

--- a/corphish/config.py
+++ b/corphish/config.py
@@ -69,6 +69,24 @@ def save_config(data: dict) -> None:
     tmp_path.replace(config_path)
 
 
+def get_update_offset() -> int:
+    """Returns the persisted Telegram update offset.
+
+    Returns:
+        The last_update_id value from config, or 0 if not set.
+    """
+    return load_config().get("last_update_id", 0)
+
+
+def save_update_offset(offset: int) -> None:
+    """Persists the Telegram update offset to config.
+
+    Args:
+        offset: The update_id + 1 to resume from on next poll.
+    """
+    save_config({"last_update_id": offset})
+
+
 def is_first_run() -> bool:
     """Returns True if no Telegram chat has been configured yet.
 

--- a/corphish/daemon.py
+++ b/corphish/daemon.py
@@ -38,6 +38,8 @@ async def run_daemon(
     poll_fn: Optional[Callable] = None,
     claude: Optional[ClaudeClient] = None,
     once: bool = False,
+    get_offset_fn: Callable = config.get_update_offset,
+    save_offset_fn: Callable = config.save_update_offset,
 ) -> None:
     """Runs the main daemon polling loop.
 
@@ -55,6 +57,8 @@ async def run_daemon(
         poll_fn: Async callable(bot, offset) returning updates.
         claude: A ClaudeClient instance.
         once: If True, process one batch of updates and return (for testing).
+        get_offset_fn: Returns the persisted update offset.
+        save_offset_fn: Persists the update offset.
     """
     token = get_token_fn()
     bot = build_bot_fn(token)
@@ -62,7 +66,7 @@ async def run_daemon(
     chat_id = cfg["chat_id"]
     poll = poll_fn or _poll_updates
     client = claude or ClaudeClient()
-    offset = 0
+    offset = get_offset_fn()
     poll_backoff = 0
 
     logger.info("Daemon started, listening on chat %s", chat_id)
@@ -83,6 +87,7 @@ async def run_daemon(
 
         for update in updates:
             offset = update.update_id + 1
+            save_offset_fn(offset)
 
             if not update.message or not update.message.text:
                 continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from corphish.cli import (
     build_parser,
     cmd_run_once,
     cmd_send,
+    cmd_skip_updates,
     cmd_status,
     dispatch,
 )
@@ -322,4 +323,70 @@ class TestDispatch:
             await dispatch(args)
             mock_boot.assert_awaited_once()
             mock_daemon.assert_not_awaited()
+
+    async def test_dispatch_skip_updates(self):
+        parser = build_parser()
+        args = parser.parse_args(["skip-updates"])
+
+        with patch(
+            "corphish.cli.cmd_skip_updates", new_callable=AsyncMock
+        ) as mock_skip:
+            await dispatch(args)
+            mock_skip.assert_awaited_once()
+
+
+# --- Parser: skip-updates ---
+
+
+class TestBuildParserSkipUpdates:
+    def test_skip_updates_command(self):
+        parser = build_parser()
+        args = parser.parse_args(["skip-updates"])
+        assert args.command == "skip-updates"
+
+
+# --- cmd_skip_updates tests ---
+
+
+class TestCmdSkipUpdates:
+    async def test_skip_updates_advances_offset(self):
+        mock_bot = MagicMock()
+        update = MagicMock()
+        update.update_id = 500
+        mock_bot.get_updates = AsyncMock(return_value=[update])
+        save_fn = MagicMock()
+
+        await cmd_skip_updates(
+            get_bot_token_fn=lambda: "fake-token",
+            build_bot_fn=lambda token: mock_bot,
+            save_offset_fn=save_fn,
+        )
+
+        mock_bot.get_updates.assert_awaited_once_with(offset=-1, timeout=0)
+        save_fn.assert_called_once_with(501)
+
+    async def test_skip_updates_no_pending(self):
+        mock_bot = MagicMock()
+        mock_bot.get_updates = AsyncMock(return_value=[])
+        save_fn = MagicMock()
+
+        await cmd_skip_updates(
+            get_bot_token_fn=lambda: "fake-token",
+            build_bot_fn=lambda token: mock_bot,
+            save_offset_fn=save_fn,
+        )
+
+        save_fn.assert_not_called()
+
+    async def test_skip_updates_exits_if_no_token(self):
+        def raise_runtime():
+            raise RuntimeError("TELEGRAM_BOT_TOKEN not set")
+
+        with pytest.raises(SystemExit) as exc_info:
+            await cmd_skip_updates(
+                get_bot_token_fn=raise_runtime,
+                build_bot_fn=lambda token: MagicMock(),
+                save_offset_fn=MagicMock(),
+            )
+        assert exc_info.value.code == 1
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,3 +75,33 @@ def test_is_first_run_true_when_config_exists_but_no_chat_id(tmp_path, monkeypat
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     config.save_config({"heartbeat": {"interval_minutes": 30}})
     assert config.is_first_run() is True
+
+
+# --- Update offset tests ---
+
+
+def test_get_update_offset_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert config.get_update_offset() == 0
+
+
+def test_get_update_offset_after_save(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    config.save_update_offset(42)
+    assert config.get_update_offset() == 42
+
+
+def test_save_update_offset_preserves_other_keys(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    config.save_config({"chat_id": 123})
+    config.save_update_offset(99)
+    cfg = config.load_config()
+    assert cfg["chat_id"] == 123
+    assert cfg["last_update_id"] == 99
+
+
+def test_save_update_offset_overwrites_previous(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    config.save_update_offset(10)
+    config.save_update_offset(20)
+    assert config.get_update_offset() == 20

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -20,7 +20,7 @@ def _make_update(update_id, chat_id, text):
     return update
 
 
-def _make_deps(chat_id=42, updates=None):
+def _make_deps(chat_id=42, updates=None, initial_offset=0):
     """Returns a dict of mock dependencies for run_daemon."""
     mock_bot = MagicMock()
     mock_claude = MagicMock()
@@ -35,6 +35,8 @@ def _make_deps(chat_id=42, updates=None):
         "poll_fn": AsyncMock(return_value=updates or []),
         "claude": mock_claude,
         "once": True,
+        "get_offset_fn": MagicMock(return_value=initial_offset),
+        "save_offset_fn": MagicMock(),
         "_bot": mock_bot,
     }
 
@@ -247,3 +249,55 @@ async def test_daemon_poll_backoff(monkeypatch):
     # Plus the normal 1-second sleep after the successful poll iteration
     backoff_sleeps = [s for s in slept if s > 1]
     assert backoff_sleeps == [2, 4, 8]
+
+
+# --- Offset persistence tests ---
+
+
+async def test_daemon_loads_offset_from_config():
+    """Daemon should pass the persisted offset to the first poll call."""
+    deps = _make_deps(chat_id=42, initial_offset=500)
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    deps["get_offset_fn"].assert_called_once()
+    deps["poll_fn"].assert_awaited_once_with(deps["_bot"], 500)
+
+
+async def test_daemon_persists_offset_for_each_update():
+    """Offset should be saved (update_id+1) for every update, before processing."""
+    updates = [
+        _make_update(100, 42, "first"),
+        _make_update(101, 42, "second"),
+    ]
+    deps = _make_deps(chat_id=42, updates=updates)
+    deps["claude"].send = AsyncMock(side_effect=["r1", "r2"])
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    save_calls = deps["save_offset_fn"].call_args_list
+    assert len(save_calls) == 2
+    assert save_calls[0].args[0] == 101
+    assert save_calls[1].args[0] == 102
+
+
+async def test_daemon_persists_offset_before_processing():
+    """Offset must be saved even for updates that are skipped (wrong chat, no text)."""
+    update = _make_update(200, 999, "wrong chat")
+    deps = _make_deps(chat_id=42, updates=[update])
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    deps["save_offset_fn"].assert_called_once_with(201)
+    deps["claude"].send.assert_not_awaited()
+
+
+async def test_daemon_persists_offset_even_when_claude_fails():
+    """Offset should be persisted even if Claude call fails."""
+    update = _make_update(300, 42, "boom")
+    deps = _make_deps(chat_id=42, updates=[update])
+    deps["claude"].send = AsyncMock(side_effect=RuntimeError("API down"))
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    deps["save_offset_fn"].assert_called_once_with(301)


### PR DESCRIPTION
## Summary
- Persist `last_update_id` in `config.toml` and load it on daemon startup as the `offset` for `get_updates()`, preventing replay of old messages after restart
- Save offset immediately per update (before Claude/send processing) so crashes mid-processing don't cause replays
- Add `corphish skip-updates` CLI command that fast-forwards offset past all pending Telegram updates
- Add `get_update_offset()` and `save_update_offset()` helpers to config module

Closes #31

## Test plan
- [x] Config: `get_update_offset()` returns 0 when unset, returns saved value after `save_update_offset()`
- [x] Config: `save_update_offset()` preserves other config keys, overwrites previous offset
- [x] Daemon: loads offset from config on startup, passes it to first poll call
- [x] Daemon: persists offset (update_id+1) for every update before processing
- [x] Daemon: persists offset even for skipped updates (wrong chat) and failed Claude calls
- [x] CLI: `skip-updates` parser recognized, dispatch wired correctly
- [x] CLI: `cmd_skip_updates` advances offset to max update_id+1, handles no pending updates, exits on missing token
- [x] All 104 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)