### PR TITLE
Catch CancelledError from SDK cancel-scope leak (closes #33)

### DIFF
--- a/corphish/claude_client.py
+++ b/corphish/claude_client.py
@@ -140,4 +140,10 @@ class ClaudeClient:
                     if message.result:
                         return message.result
 
+        # Yield control so any pending anyio cancel-scope cleanup from the
+        # SDK's internal task group settles before the caller does further I/O.
+        # Without this, a leaked cancellation can fire on the next await
+        # (e.g. send_message), causing CancelledError.  See issue #33.
+        await asyncio.sleep(0)
+
         return last_text

--- a/corphish/daemon.py
+++ b/corphish/daemon.py
@@ -103,6 +103,12 @@ async def run_daemon(
             except Exception:
                 logger.exception("Claude call failed for message: %s", user_text)
                 continue
+            except asyncio.CancelledError:
+                logger.warning(
+                    "Claude call cancelled (SDK cleanup leak) for message: %s",
+                    user_text,
+                )
+                continue
 
             logger.info("[assistant] %s", reply)
 
@@ -111,6 +117,11 @@ async def run_daemon(
             except Exception:
                 logger.exception(
                     "Failed to send reply via Telegram for message: %s",
+                    user_text,
+                )
+            except asyncio.CancelledError:
+                logger.warning(
+                    "send_message cancelled (SDK cleanup leak) for message: %s",
                     user_text,
                 )
 

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -455,3 +455,43 @@ async def test_send_closes_generator_on_normal_exhaustion():
     result = await client.send("test")
     assert result == "hello"
     assert closed, "async generator was not properly closed"
+
+
+# ---------------------------------------------------------------------------
+# send() — cancel scope cleanup mitigation (issue #33)
+# ---------------------------------------------------------------------------
+
+
+async def test_send_yields_control_after_stream(monkeypatch):
+    """Regression #33: send() must await asyncio.sleep(0) after the stream
+    closes so any leaked cancel-scope cleanup settles before the caller
+    does further I/O.
+    """
+    from claude_agent_sdk import AssistantMessage, TextBlock, ResultMessage
+
+    sleep_called_with = []
+    original_sleep = asyncio.sleep
+
+    async def spy_sleep(seconds, *args, **kwargs):
+        sleep_called_with.append(seconds)
+        return await original_sleep(seconds, *args, **kwargs)
+
+    monkeypatch.setattr("corphish.claude_client.asyncio.sleep", spy_sleep)
+
+    messages = [
+        AssistantMessage(content=[TextBlock(text="hi")], model="test"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=1,
+            session_id="s1",
+        ),
+    ]
+    client = _make_client(query_fn=_make_query_fn(messages))
+    result = await client.send("test")
+    assert result == "hi"
+    assert 0 in sleep_called_with, (
+        "asyncio.sleep(0) was not called after stream closed"
+    )

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -301,3 +301,58 @@ async def test_daemon_persists_offset_even_when_claude_fails():
     await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
 
     deps["save_offset_fn"].assert_called_once_with(301)
+
+
+# --- CancelledError resilience tests (issue #33) ---
+
+
+async def test_daemon_continues_after_send_message_cancelled_error():
+    """Regression #33: CancelledError on send_message must not crash the daemon."""
+    updates = [
+        _make_update(1, 42, "first"),
+        _make_update(2, 42, "second"),
+    ]
+    deps = _make_deps(chat_id=42, updates=updates)
+    deps["claude"].send = AsyncMock(side_effect=["r1", "r2"])
+    deps["send_message_fn"] = AsyncMock(
+        side_effect=[asyncio.CancelledError("cancel scope leak"), None]
+    )
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    # Both messages should be processed; the daemon must not exit
+    assert deps["claude"].send.await_count == 2
+    assert deps["send_message_fn"].await_count == 2
+
+
+async def test_daemon_continues_after_claude_cancelled_error():
+    """Regression #33: CancelledError from Claude SDK must not crash the daemon."""
+    updates = [
+        _make_update(1, 42, "boom"),
+        _make_update(2, 42, "ok"),
+    ]
+    deps = _make_deps(chat_id=42, updates=updates)
+    deps["claude"].send = AsyncMock(
+        side_effect=[asyncio.CancelledError("cancel scope leak"), "reply-ok"]
+    )
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    assert deps["claude"].send.await_count == 2
+    # First message's send_message should be skipped; only second succeeds
+    deps["send_message_fn"].assert_awaited_once_with(deps["_bot"], 42, "reply-ok")
+
+
+async def test_daemon_logs_cancelled_error_on_send(caplog):
+    """CancelledError on send_message should be logged as a warning, not crash."""
+    updates = [_make_update(1, 42, "hi")]
+    deps = _make_deps(chat_id=42, updates=[_make_update(1, 42, "hi")])
+    deps["claude"].send = AsyncMock(return_value="reply")
+    deps["send_message_fn"] = AsyncMock(
+        side_effect=asyncio.CancelledError("cancel scope leak")
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    assert any("send_message cancelled" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- **daemon.py**: Catch `asyncio.CancelledError` (a `BaseException`, not `Exception`) around both `client.send()` and `send_message_fn()` so the daemon stays alive when the Agent SDK's anyio cancel-scope cleanup leaks a cancellation into the caller's task
- **claude_client.py**: `await asyncio.sleep(0)` after the `aclosing` block to give pending cancel-scope cleanup a chance to settle before the caller does further I/O
- Added 4 regression tests covering CancelledError on both send_message and Claude calls

## Test plan

- [x] All 108 tests pass (including 4 new regression tests)
- [ ] Deploy and verify daemon stays alive after processing a message (no launchd restart)
- [ ] Confirm reply is delivered to Telegram without CancelledError

🤖 Generated with [Claude Code](https://claude.com/claude-code)