### PR TITLE
Explicitly close SDK query generator in same task to prevent cross-ta…

### DIFF
--- a/corphish/claude_client.py
+++ b/corphish/claude_client.py
@@ -123,21 +123,28 @@ class ClaudeClient:
         """
         last_text = ""
         result_text = None
+        gen = self._query(prompt=user_text, options=self._options)
 
-        async for message in self._query(
-            prompt=user_text, options=self._options
-        ):
-            if isinstance(message, AssistantMessage):
-                parts = [
-                    block.text
-                    for block in message.content
-                    if isinstance(block, TextBlock)
-                ]
-                if parts:
-                    last_text = "\n".join(parts)
-            elif isinstance(message, ResultMessage):
-                if message.result:
-                    result_text = message.result
-                    break
+        try:
+            async for message in gen:
+                if isinstance(message, AssistantMessage):
+                    parts = [
+                        block.text
+                        for block in message.content
+                        if isinstance(block, TextBlock)
+                    ]
+                    if parts:
+                        last_text = "\n".join(parts)
+                elif isinstance(message, ResultMessage):
+                    if message.result:
+                        result_text = message.result
+                        break
+        finally:
+            await gen.aclose()
+            # Yield control so any pending anyio cancel-scope cleanup from the
+            # SDK's internal task group settles before the caller does further
+            # I/O.  Without this, a leaked cancellation can fire on the next
+            # await (e.g. send_message), causing CancelledError.  See #33.
+            await asyncio.sleep(0)
 
         return result_text or last_text

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -388,11 +388,11 @@ async def test_lock_serialises_calls():
 
 
 async def test_send_closes_generator_on_early_return():
-    """send() must stop consuming after ResultMessage.result via break.
+    """send() must close the generator in the same task after breaking.
 
-    Regression test for issue #27: the generator is no longer wrapped in
-    aclosing(); instead we break out of the loop. The result must still be
-    correct and no messages after the break should affect the return value.
+    Regression test for issues #27 and #36: the generator is explicitly closed
+    via aclose() in the finally block so the SDK's cancel scope is torn down in
+    the originating task, not deferred to GC in a different task.
     """
     from claude_agent_sdk import AssistantMessage, TextBlock, ResultMessage
 
@@ -417,15 +417,13 @@ async def test_send_closes_generator_on_early_return():
             yield AssistantMessage(
                 content=[TextBlock(text="should not reach")], model="test"
             )
-        except GeneratorExit:
-            closed = True
-            raise
         finally:
             closed = True
 
     client = _make_client(query_fn=gen_query)
     result = await client.send("test")
     assert result == "final"
+    assert closed, "async generator was not closed after early break"
 
 
 async def test_send_closes_generator_on_normal_exhaustion():


### PR DESCRIPTION
…sk cancel scope crash (closes #36)

PR #35 replaced aclosing+return with a bare break, which avoided the CancelledError leak (#33) but left the generator for GC to finalize. When GC ran aclose() in a different task, the SDK's anyio cancel scope raised RuntimeError ("exit cancel scope in a different task").

Fix: hold the generator in a variable, use try/finally to call aclose() in the originating task, then sleep(0) to absorb any deferred cancel-scope cleanup. This handles both the cross-task RuntimeError (#36) and the CancelledError leak (#33).