### PR TITLE
Add /reset command to clear conversation history

### DIFF
--- a/corphish/claude_client.py
+++ b/corphish/claude_client.py
@@ -107,6 +107,26 @@ class ClaudeClient:
         """Returns True if the lock is currently held."""
         return self.lock.locked()
 
+    def reset(self) -> None:
+        """Resets the conversation by recreating the options.
+
+        This clears the conversation history and starts fresh. Any markdown
+        files or other artifacts created during the conversation are preserved.
+        """
+        model = self._options.model or _DEFAULT_MODEL
+        system_prompt_config = self._options.system_prompt
+
+        # Extract the custom system prompt if it was appended to preset
+        custom_prompt = None
+        if isinstance(system_prompt_config, dict):
+            if system_prompt_config.get("type") == "preset":
+                custom_prompt = system_prompt_config.get("append")
+
+        self._options = _build_options(
+            model=model,
+            system_prompt=custom_prompt,
+        )
+
     async def send(self, user_text: str) -> str:
         """Sends a user message and returns Claude's final text response.
 

--- a/corphish/daemon.py
+++ b/corphish/daemon.py
@@ -97,18 +97,28 @@ async def run_daemon(
             user_text = update.message.text
             logger.info("[user] %s", user_text)
 
-            try:
+            # Handle /reset command
+            if user_text.strip().startswith("/reset"):
                 async with client.lock:
-                    reply = await client.send(user_text)
-            except Exception:
-                logger.exception("Claude call failed for message: %s", user_text)
-                continue
-            except asyncio.CancelledError:
-                logger.warning(
-                    "Claude call cancelled (SDK cleanup leak) for message: %s",
-                    user_text,
+                    client.reset()
+                reply = (
+                    "Context and conversation history have been reset. "
+                    "Starting fresh while preserving any files created."
                 )
-                continue
+                logger.info("[system] Reset conversation")
+            else:
+                try:
+                    async with client.lock:
+                        reply = await client.send(user_text)
+                except Exception:
+                    logger.exception("Claude call failed for message: %s", user_text)
+                    continue
+                except asyncio.CancelledError:
+                    logger.warning(
+                        "Claude call cancelled (SDK cleanup leak) for message: %s",
+                        user_text,
+                    )
+                    continue
 
             logger.info("[assistant] %s", reply)
 

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -500,3 +500,87 @@ async def test_send_exhausts_generator_without_break():
         "ResultMessage",
         "AssistantMessage",
     ]
+
+
+# ---------------------------------------------------------------------------
+# reset() tests
+# ---------------------------------------------------------------------------
+
+
+def test_reset_recreates_options():
+    """reset() should create fresh options to clear conversation history."""
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    client = _make_client(
+        options=ClaudeAgentOptions(
+            system_prompt={
+                "type": "preset",
+                "preset": "claude_code",
+                "append": "custom prompt",
+            },
+            model="claude-sonnet-4-5-20250929",
+            continue_conversation=True,
+        )
+    )
+    old_options = client._options
+
+    client.reset()
+
+    # Options should be recreated (new object)
+    assert client._options is not old_options
+    # But preserve the model and system prompt
+    assert client._options.model == "claude-sonnet-4-5-20250929"
+    assert client._options.system_prompt["type"] == "preset"
+    assert client._options.system_prompt["preset"] == "claude_code"
+    assert client._options.system_prompt["append"] == "custom prompt"
+
+
+def test_reset_preserves_model():
+    """reset() should preserve the model setting."""
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    client = _make_client(
+        options=ClaudeAgentOptions(
+            system_prompt="test", model="claude-haiku-4-5-20251001"
+        )
+    )
+
+    client.reset()
+
+    assert client._options.model == "claude-haiku-4-5-20251001"
+
+
+async def test_reset_clears_conversation_history():
+    """After reset, send() should start a fresh conversation."""
+    from claude_agent_sdk import AssistantMessage, TextBlock, ResultMessage
+
+    call_count = 0
+
+    async def tracking_query(*, prompt, options):
+        nonlocal call_count
+        call_count += 1
+        yield AssistantMessage(
+            content=[TextBlock(text=f"response-{call_count}")], model="test"
+        )
+        yield ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=1,
+            session_id="s1",
+        )
+
+    client = _make_client(query_fn=tracking_query)
+
+    # First conversation
+    result1 = await client.send("hello")
+    assert result1 == "response-1"
+
+    # Reset
+    client.reset()
+
+    # Second conversation should be fresh (new options passed to query)
+    result2 = await client.send("hi again")
+    assert result2 == "response-2"
+    assert call_count == 2

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -356,3 +356,71 @@ async def test_daemon_logs_cancelled_error_on_send(caplog):
         await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
 
     assert any("send_message cancelled" in r.message for r in caplog.records)
+
+
+# --- /reset command tests ---
+
+
+async def test_daemon_handles_reset_command():
+    """/reset command should reset the client and send confirmation."""
+    update = _make_update(1, 42, "/reset")
+    deps = _make_deps(chat_id=42, updates=[update])
+    deps["claude"].reset = MagicMock()
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    # reset() should be called
+    deps["claude"].reset.assert_called_once()
+    # Claude.send() should NOT be called (command handled internally)
+    deps["claude"].send.assert_not_awaited()
+    # Confirmation message should be sent
+    deps["send_message_fn"].assert_awaited_once()
+    sent_message = deps["send_message_fn"].call_args.args[2]
+    assert "reset" in sent_message.lower()
+    assert "context" in sent_message.lower() or "history" in sent_message.lower()
+
+
+async def test_daemon_handles_reset_command_with_whitespace():
+    """/reset with leading/trailing whitespace should still work."""
+    update = _make_update(1, 42, "  /reset  ")
+    deps = _make_deps(chat_id=42, updates=[update])
+    deps["claude"].reset = MagicMock()
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    deps["claude"].reset.assert_called_once()
+    deps["claude"].send.assert_not_awaited()
+
+
+async def test_daemon_normal_message_after_reset():
+    """/reset followed by a normal message should work correctly."""
+    updates = [
+        _make_update(1, 42, "/reset"),
+        _make_update(2, 42, "hello"),
+    ]
+    deps = _make_deps(chat_id=42, updates=updates)
+    deps["claude"].reset = MagicMock()
+    deps["claude"].send = AsyncMock(return_value="hi there")
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    # reset called once
+    deps["claude"].reset.assert_called_once()
+    # Claude.send() called once (for "hello")
+    deps["claude"].send.assert_awaited_once_with("hello")
+    # Two messages sent: reset confirmation + Claude's reply
+    assert deps["send_message_fn"].await_count == 2
+
+
+async def test_daemon_reset_does_not_match_partial():
+    """Message containing /reset but not starting with it should be sent to Claude."""
+    update = _make_update(1, 42, "How do I /reset my password?")
+    deps = _make_deps(chat_id=42, updates=[update])
+    deps["claude"].reset = MagicMock()
+
+    await run_daemon(**{k: v for k, v in deps.items() if k != "_bot"})
+
+    # Should not trigger reset
+    deps["claude"].reset.assert_not_called()
+    # Should be sent to Claude
+    deps["claude"].send.assert_awaited_once_with("How do I /reset my password?")


### PR DESCRIPTION
Implements issue #16 by adding a /reset command that clears the context and conversation history while preserving any files that have been created.

Changes:
- Added ClaudeClient.reset() method to recreate options and clear history
- Modified daemon to detect /reset command and handle it specially
- Added comprehensive tests for both ClaudeClient and daemon behavior
- Ensures /reset only triggers when at the start of a message