### PR TITLE
Change default model to Claude Opus 4.5

### DIFF
--- a/corphish/claude_client.py
+++ b/corphish/claude_client.py
@@ -17,7 +17,7 @@ from . import config
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+_DEFAULT_MODEL = "claude-opus-4-5-20251101"
 
 _DISALLOWED_TOOLS = ["EnterPlanMode", "ExitPlanMode", "AskUserQuestion"]
 


### PR DESCRIPTION
## Summary
- Changes the default model from `claude-sonnet-4-5-20250929` to `claude-opus-4-5-20251101`

Closes #38

## Test plan
- [x] All 115 existing tests pass
- [ ] Verify Claude responses use Opus 4.5 after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)