### PR TITLE
Implement heartbeat runner component

### DIFF
--- a/corphish/config.py
+++ b/corphish/config.py
@@ -94,3 +94,25 @@ def is_first_run() -> bool:
         True if chat_id is absent from config, False otherwise.
     """
     return "chat_id" not in load_config()
+
+
+# Default heartbeat interval: 30 minutes in seconds
+_DEFAULT_HEARTBEAT_INTERVAL = 30 * 60
+
+
+def get_heartbeat_interval() -> int:
+    """Returns the heartbeat interval in seconds.
+
+    Returns:
+        The heartbeat_interval value from config, or 1800 (30 minutes) if not set.
+    """
+    return load_config().get("heartbeat_interval", _DEFAULT_HEARTBEAT_INTERVAL)
+
+
+def save_heartbeat_interval(interval: int) -> None:
+    """Persists the heartbeat interval to config.
+
+    Args:
+        interval: The heartbeat interval in seconds.
+    """
+    save_config({"heartbeat_interval": interval})

--- a/corphish/daemon.py
+++ b/corphish/daemon.py
@@ -1,4 +1,4 @@
-"""Daemon components: message consumer, processor, and integration via SQLite."""
+"""Daemon components: message consumer, processor, heartbeat, and integration via SQLite."""
 
 import asyncio
 import logging
@@ -14,6 +14,21 @@ logger = logging.getLogger(__name__)
 
 _BACKOFF_BASE = 1
 _BACKOFF_MAX = 60
+
+
+def _load_heartbeat_prompt() -> str:
+    """Loads the heartbeat prompt from HEARTBEAT.md.
+
+    Returns:
+        The contents of HEARTBEAT.md, or a minimal fallback.
+    """
+    heartbeat_path = Path(__file__).parent.parent / "HEARTBEAT.md"
+    if heartbeat_path.exists():
+        return heartbeat_path.read_text()
+    return (
+        "This is a periodic heartbeat. Decide if there is anything worth "
+        "saying to the user unprompted. Default to silence."
+    )
 
 
 async def _poll_updates(bot: Bot, offset: int, timeout: int = 10):
@@ -213,6 +228,100 @@ async def run_message_processor(
         await asyncio.sleep(1)
 
 
+def _is_trivial_response(response: str) -> bool:
+    """Determines if a heartbeat response is trivial and should be suppressed.
+
+    A response is trivial if it's empty, just whitespace, or explicitly
+    indicates the assistant chose to stay silent.
+
+    Args:
+        response: The response text from Claude.
+
+    Returns:
+        True if the response should be suppressed, False if it should be sent.
+    """
+    if not response or not response.strip():
+        return True
+
+    # Common patterns indicating intentional silence
+    lowered = response.lower().strip()
+    trivial_patterns = [
+        "no message",
+        "nothing to say",
+        "staying silent",
+        "stay silent",
+        "no response",
+        "no update",
+        "silence",
+    ]
+    return any(pattern in lowered for pattern in trivial_patterns)
+
+
+async def run_heartbeat_runner(
+    *,
+    claude: ClaudeClient,
+    once: bool = False,
+    db_path: Optional[Path] = None,
+    insert_outgoing_fn: Callable = db.insert_outgoing_message,
+    get_interval_fn: Callable = config.get_heartbeat_interval,
+    load_prompt_fn: Callable = _load_heartbeat_prompt,
+) -> None:
+    """Runs the heartbeat runner loop.
+
+    Fires at configurable intervals (default 30 minutes) and sends a check-in
+    prompt to Claude. Only surfaces meaningful responses to users. Skips
+    execution if Claude is currently busy processing a message.
+
+    Args:
+        claude: A ClaudeClient instance (shared with processor for lock check).
+        once: If True, fire once and return (for testing).
+        db_path: Path to the database file.
+        insert_outgoing_fn: Function to insert outgoing message.
+        get_interval_fn: Function to get heartbeat interval in seconds.
+        load_prompt_fn: Function to load the heartbeat prompt.
+    """
+    prompt = load_prompt_fn()
+    logger.info("Heartbeat runner started")
+
+    while True:
+        interval = get_interval_fn()
+        logger.debug("Heartbeat sleeping for %d seconds", interval)
+        await asyncio.sleep(interval)
+
+        # Skip if Claude is busy processing a message
+        if claude.busy:
+            logger.info("[heartbeat] Skipping — Claude is busy")
+            if once:
+                break
+            continue
+
+        logger.info("[heartbeat] Firing heartbeat check-in")
+
+        try:
+            async with claude.lock:
+                response = await claude.send(prompt)
+        except Exception:
+            logger.exception("Heartbeat Claude call failed")
+            if once:
+                break
+            continue
+        except asyncio.CancelledError:
+            logger.warning("Heartbeat Claude call cancelled")
+            if once:
+                break
+            continue
+
+        # Only surface non-trivial responses
+        if _is_trivial_response(response):
+            logger.info("[heartbeat] Response was trivial, suppressing")
+        else:
+            logger.info("[heartbeat] Sending response: %s", response[:50])
+            await insert_outgoing_fn(text=response, db_path=db_path)
+
+        if once:
+            break
+
+
 async def run_daemon(
     *,
     get_token_fn: Callable = chat.get_bot_token,
@@ -225,12 +334,13 @@ async def run_daemon(
     get_offset_fn: Callable = config.get_update_offset,
     save_offset_fn: Callable = config.save_update_offset,
     db_path: Optional[Path] = None,
+    enable_heartbeat: bool = True,
 ) -> None:
-    """Runs both message consumer and processor concurrently.
+    """Runs message consumer, processor, and heartbeat runner concurrently.
 
-    This is the main entry point that starts both the message consumer
-    (polls Telegram) and message processor (polls DB, processes via Claude)
-    loops concurrently.
+    This is the main entry point that starts the message consumer
+    (polls Telegram), message processor (polls DB, processes via Claude),
+    and heartbeat runner (periodic check-ins) loops concurrently.
 
     Args:
         get_token_fn: Returns the Telegram bot token.
@@ -238,19 +348,23 @@ async def run_daemon(
         load_config_fn: Returns the current config dict.
         send_message_fn: Sends a message via Telegram.
         poll_fn: Async callable(bot, offset) returning updates.
-        claude: A ClaudeClient instance.
+        claude: A ClaudeClient instance (shared between processor and heartbeat).
         once: If True, process one iteration and return (for testing).
         get_offset_fn: Returns the persisted update offset.
         save_offset_fn: Persists the update offset.
         db_path: Path to the database file.
+        enable_heartbeat: If True, run the heartbeat runner (default True).
     """
     # Initialize database
     await db.init_db(db_path)
 
+    # Create shared Claude client if not provided
+    client = claude or ClaudeClient()
+
     logger.info("Daemon started")
 
-    # Run consumer and processor concurrently
-    await asyncio.gather(
+    # Build list of tasks to run concurrently
+    tasks = [
         run_message_consumer(
             get_token_fn=get_token_fn,
             build_bot_fn=build_bot_fn,
@@ -266,8 +380,19 @@ async def run_daemon(
             build_bot_fn=build_bot_fn,
             load_config_fn=load_config_fn,
             send_message_fn=send_message_fn,
-            claude=claude,
+            claude=client,
             once=once,
             db_path=db_path,
         ),
-    )
+    ]
+
+    if enable_heartbeat:
+        tasks.append(
+            run_heartbeat_runner(
+                claude=client,
+                once=once,
+                db_path=db_path,
+            )
+        )
+
+    await asyncio.gather(*tasks)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,3 +105,34 @@ def test_save_update_offset_overwrites_previous(tmp_path, monkeypatch):
     config.save_update_offset(10)
     config.save_update_offset(20)
     assert config.get_update_offset() == 20
+
+
+# --- Heartbeat interval tests ---
+
+
+def test_get_heartbeat_interval_default(tmp_path, monkeypatch):
+    """Default heartbeat interval should be 30 minutes (1800 seconds)."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert config.get_heartbeat_interval() == 1800
+
+
+def test_get_heartbeat_interval_after_save(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    config.save_heartbeat_interval(900)  # 15 minutes
+    assert config.get_heartbeat_interval() == 900
+
+
+def test_save_heartbeat_interval_preserves_other_keys(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    config.save_config({"chat_id": 123})
+    config.save_heartbeat_interval(600)
+    cfg = config.load_config()
+    assert cfg["chat_id"] == 123
+    assert cfg["heartbeat_interval"] == 600
+
+
+def test_save_heartbeat_interval_overwrites_previous(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    config.save_heartbeat_interval(1800)
+    config.save_heartbeat_interval(3600)
+    assert config.get_heartbeat_interval() == 3600

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from corphish.daemon import run_daemon, run_message_consumer, run_message_processor
+from corphish.daemon import (
+    _is_trivial_response,
+    run_daemon,
+    run_heartbeat_runner,
+    run_message_consumer,
+    run_message_processor,
+)
 
 
 def _make_update(update_id, chat_id, text):
@@ -197,20 +203,21 @@ async def test_daemon_initializes_database(tmp_path):
     """run_daemon should initialize the database."""
     db_path = tmp_path / "test.db"
 
-    # Mock the consumer and processor to return immediately
+    # Mock all components to return immediately
     with patch("corphish.daemon.run_message_consumer", new=AsyncMock()):
         with patch("corphish.daemon.run_message_processor", new=AsyncMock()):
-            await run_daemon(
-                get_token_fn=MagicMock(return_value="tok"),
-                build_bot_fn=MagicMock(return_value=MagicMock()),
-                load_config_fn=MagicMock(return_value={"chat_id": 42}),
-                send_message_fn=AsyncMock(),
-                poll_fn=AsyncMock(return_value=[]),
-                once=True,
-                get_offset_fn=MagicMock(return_value=0),
-                save_offset_fn=MagicMock(),
-                db_path=db_path,
-            )
+            with patch("corphish.daemon.run_heartbeat_runner", new=AsyncMock()):
+                await run_daemon(
+                    get_token_fn=MagicMock(return_value="tok"),
+                    build_bot_fn=MagicMock(return_value=MagicMock()),
+                    load_config_fn=MagicMock(return_value={"chat_id": 42}),
+                    send_message_fn=AsyncMock(),
+                    poll_fn=AsyncMock(return_value=[]),
+                    once=True,
+                    get_offset_fn=MagicMock(return_value=0),
+                    save_offset_fn=MagicMock(),
+                    db_path=db_path,
+                )
 
     # Database file should exist
     assert db_path.exists()
@@ -231,17 +238,198 @@ async def test_daemon_runs_consumer_and_processor_concurrently():
 
     with patch("corphish.daemon.run_message_consumer", new=mock_consumer):
         with patch("corphish.daemon.run_message_processor", new=mock_processor):
-            await run_daemon(
-                get_token_fn=MagicMock(return_value="tok"),
-                build_bot_fn=MagicMock(return_value=MagicMock()),
-                load_config_fn=MagicMock(return_value={"chat_id": 42}),
-                send_message_fn=AsyncMock(),
-                poll_fn=AsyncMock(return_value=[]),
-                once=True,
-                get_offset_fn=MagicMock(return_value=0),
-                save_offset_fn=MagicMock(),
-            )
+            with patch("corphish.daemon.run_heartbeat_runner", new=AsyncMock()):
+                await run_daemon(
+                    get_token_fn=MagicMock(return_value="tok"),
+                    build_bot_fn=MagicMock(return_value=MagicMock()),
+                    load_config_fn=MagicMock(return_value={"chat_id": 42}),
+                    send_message_fn=AsyncMock(),
+                    poll_fn=AsyncMock(return_value=[]),
+                    once=True,
+                    get_offset_fn=MagicMock(return_value=0),
+                    save_offset_fn=MagicMock(),
+                )
 
     assert consumer_called
     assert processor_called
+
+
+# --- Trivial Response Detection Tests ---
+
+
+def test_is_trivial_response_empty():
+    """Empty responses are trivial."""
+    assert _is_trivial_response("") is True
+    assert _is_trivial_response("   ") is True
+    assert _is_trivial_response(None) is True
+
+
+def test_is_trivial_response_silence_patterns():
+    """Responses indicating silence should be trivial."""
+    assert _is_trivial_response("No message needed.") is True
+    assert _is_trivial_response("Nothing to say right now.") is True
+    assert _is_trivial_response("Staying silent.") is True
+    assert _is_trivial_response("I'll stay silent on this one.") is True
+    assert _is_trivial_response("No response necessary.") is True
+    assert _is_trivial_response("No update at this time.") is True
+    assert _is_trivial_response("Silence") is True
+
+
+def test_is_trivial_response_non_trivial():
+    """Meaningful responses should not be trivial."""
+    assert _is_trivial_response("Remember to submit your report by 5pm.") is False
+    assert _is_trivial_response("I noticed an error in the build logs.") is False
+    assert _is_trivial_response("Your meeting starts in 10 minutes.") is False
+
+
+# --- Heartbeat Runner Tests ---
+
+
+def _make_heartbeat_deps():
+    """Returns a dict of mock dependencies for run_heartbeat_runner."""
+    mock_claude = MagicMock()
+    mock_claude.lock = asyncio.Lock()
+    mock_claude.busy = False
+    mock_claude.send = AsyncMock(return_value="meaningful response")
+
+    return {
+        "claude": mock_claude,
+        "once": True,
+        "insert_outgoing_fn": AsyncMock(return_value=1),
+        "get_interval_fn": MagicMock(return_value=0),  # No delay for testing
+        "load_prompt_fn": MagicMock(return_value="Heartbeat prompt"),
+    }
+
+
+async def test_heartbeat_sends_meaningful_response():
+    """Heartbeat should send non-trivial responses to database."""
+    deps = _make_heartbeat_deps()
+    deps["claude"].send = AsyncMock(return_value="Remember your meeting at 3pm!")
+
+    await run_heartbeat_runner(**deps)
+
+    deps["claude"].send.assert_awaited_once_with("Heartbeat prompt")
+    deps["insert_outgoing_fn"].assert_awaited_once_with(
+        text="Remember your meeting at 3pm!", db_path=None
+    )
+
+
+async def test_heartbeat_suppresses_trivial_response():
+    """Heartbeat should not send trivial responses."""
+    deps = _make_heartbeat_deps()
+    deps["claude"].send = AsyncMock(return_value="No message needed.")
+
+    await run_heartbeat_runner(**deps)
+
+    deps["claude"].send.assert_awaited_once()
+    deps["insert_outgoing_fn"].assert_not_awaited()
+
+
+async def test_heartbeat_suppresses_empty_response():
+    """Heartbeat should not send empty responses."""
+    deps = _make_heartbeat_deps()
+    deps["claude"].send = AsyncMock(return_value="")
+
+    await run_heartbeat_runner(**deps)
+
+    deps["claude"].send.assert_awaited_once()
+    deps["insert_outgoing_fn"].assert_not_awaited()
+
+
+async def test_heartbeat_skips_when_claude_busy():
+    """Heartbeat should skip when Claude is busy."""
+    deps = _make_heartbeat_deps()
+    deps["claude"].busy = True
+
+    await run_heartbeat_runner(**deps)
+
+    deps["claude"].send.assert_not_awaited()
+    deps["insert_outgoing_fn"].assert_not_awaited()
+
+
+async def test_heartbeat_continues_after_claude_failure():
+    """Heartbeat should handle Claude failures gracefully."""
+    deps = _make_heartbeat_deps()
+    deps["claude"].send = AsyncMock(side_effect=RuntimeError("API down"))
+
+    # Should not raise
+    await run_heartbeat_runner(**deps)
+
+    deps["claude"].send.assert_awaited_once()
+    deps["insert_outgoing_fn"].assert_not_awaited()
+
+
+async def test_heartbeat_uses_configurable_interval():
+    """Heartbeat should use interval from config."""
+    deps = _make_heartbeat_deps()
+    # Use 0 for testing, just verify the function is called
+    deps["get_interval_fn"] = MagicMock(return_value=0)
+
+    await run_heartbeat_runner(**deps)
+
+    deps["get_interval_fn"].assert_called()
+
+
+async def test_daemon_includes_heartbeat_runner():
+    """run_daemon should start heartbeat runner when enabled."""
+    consumer_called = False
+    processor_called = False
+    heartbeat_called = False
+
+    async def mock_consumer(**kwargs):
+        nonlocal consumer_called
+        consumer_called = True
+
+    async def mock_processor(**kwargs):
+        nonlocal processor_called
+        processor_called = True
+
+    async def mock_heartbeat(**kwargs):
+        nonlocal heartbeat_called
+        heartbeat_called = True
+
+    with patch("corphish.daemon.run_message_consumer", new=mock_consumer):
+        with patch("corphish.daemon.run_message_processor", new=mock_processor):
+            with patch("corphish.daemon.run_heartbeat_runner", new=mock_heartbeat):
+                await run_daemon(
+                    get_token_fn=MagicMock(return_value="tok"),
+                    build_bot_fn=MagicMock(return_value=MagicMock()),
+                    load_config_fn=MagicMock(return_value={"chat_id": 42}),
+                    send_message_fn=AsyncMock(),
+                    poll_fn=AsyncMock(return_value=[]),
+                    once=True,
+                    get_offset_fn=MagicMock(return_value=0),
+                    save_offset_fn=MagicMock(),
+                    enable_heartbeat=True,
+                )
+
+    assert consumer_called
+    assert processor_called
+    assert heartbeat_called
+
+
+async def test_daemon_can_disable_heartbeat():
+    """run_daemon should not start heartbeat when disabled."""
+    heartbeat_called = False
+
+    async def mock_heartbeat(**kwargs):
+        nonlocal heartbeat_called
+        heartbeat_called = True
+
+    with patch("corphish.daemon.run_message_consumer", new=AsyncMock()):
+        with patch("corphish.daemon.run_message_processor", new=AsyncMock()):
+            with patch("corphish.daemon.run_heartbeat_runner", new=mock_heartbeat):
+                await run_daemon(
+                    get_token_fn=MagicMock(return_value="tok"),
+                    build_bot_fn=MagicMock(return_value=MagicMock()),
+                    load_config_fn=MagicMock(return_value={"chat_id": 42}),
+                    send_message_fn=AsyncMock(),
+                    poll_fn=AsyncMock(return_value=[]),
+                    once=True,
+                    get_offset_fn=MagicMock(return_value=0),
+                    save_offset_fn=MagicMock(),
+                    enable_heartbeat=False,
+                )
+
+    assert not heartbeat_called
 


### PR DESCRIPTION
Implements issue #44 by adding a heartbeat runner that periodically checks in with Claude and sends proactive messages when meaningful.

## Changes

### Config Layer (corphish/config.py)
- Added get_heartbeat_interval() - returns interval in seconds (default 1800 = 30 minutes)
- Added save_heartbeat_interval() - persists custom interval to config.toml
- 4 new tests for heartbeat config

### Daemon (corphish/daemon.py)
- Added _load_heartbeat_prompt() - loads prompt from HEARTBEAT.md
- Added _is_trivial_response() - filters out trivial/silence responses
- Added run_heartbeat_runner() - periodic loop that:
  - Fires at configurable intervals (default 30 minutes)
  - Skips if Claude is busy (checks client.busy property)
  - Sends HEARTBEAT.md prompt via shared ClaudeClient
  - Only surfaces meaningful responses, suppresses trivial ones
- Updated run_daemon() to run heartbeat runner concurrently
- Added enable_heartbeat flag (default True) to disable if needed
- 11 new tests covering:
  - Trivial response detection (empty, silence patterns)
  - Meaningful response delivery
  - Skip when Claude busy
  - Error handling
  - Integration with daemon

## Architecture

The heartbeat runner:
1. Sleeps for configured interval (reads from config each cycle)
2. Checks if Claude is busy - skips if so
3. Sends HEARTBEAT.md prompt to Claude
4. Filters response - only sends non-trivial messages
5. Inserts meaningful responses to outgoing messages in database

Shares the ClaudeClient instance with message processor for:
- Lock-based concurrency (busy detection)
- Conversation context continuity

## Test Coverage

All 130 tests pass (15 new tests added).