### PR TITLE
Enable auto-compaction for long-running conversations

### DIFF
--- a/corphish/claude_client.py
+++ b/corphish/claude_client.py
@@ -65,6 +65,7 @@ def _build_options(
         model=model,
         continue_conversation=True,
         cwd=str(config.get_config_dir()),
+        settings='{"autoCompact": true}',
     )
 
 

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -138,6 +138,15 @@ def test_build_options_enables_continue_conversation():
     assert opts.continue_conversation is True
 
 
+def test_build_options_enables_auto_compaction():
+    import json
+
+    opts = _build_options(system_prompt="test")
+    assert opts.settings is not None
+    settings = json.loads(opts.settings)
+    assert settings.get("autoCompact") is True
+
+
 # ---------------------------------------------------------------------------
 # Client construction tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `{"autoCompact": true}` to `ClaudeAgentOptions.settings` in `_build_options`
- This explicitly enables Claude Code's built-in context compaction, which fires automatically at the default threshold (~78% of the context window)
- When the context approaches the limit, Claude Code summarizes older conversation history so the session can continue without hitting the token ceiling
- Closes #24

## Test plan

- [ ] `test_build_options_enables_auto_compaction` verifies the setting is present and parsed correctly
- [ ] All 22 existing `test_claude_client` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)